### PR TITLE
feat: user time from the worker code rather DB

### DIFF
--- a/packages/btcindexer/db/migrations/0001_initial_schema.sql
+++ b/packages/btcindexer/db/migrations/0001_initial_schema.sql
@@ -2,7 +2,7 @@
 CREATE TABLE btc_blocks (
     height INTEGER PRIMARY KEY,
     hash TEXT NOT NULL UNIQUE,
-    processed_at REAL DEFAULT (unixepoch('subsec')),
+    processed_at INTEGER NOT NULL, -- timestamp_ms
 	status TEXT NOT NULL DEFAULT 'new' CHECK (status IN ('new', 'scanned')) -- 'new' | 'scanned'
 ) STRICT;
 

--- a/packages/btcindexer/src/btcindexer.ts
+++ b/packages/btcindexer/src/btcindexer.ts
@@ -281,11 +281,12 @@ export class Indexer implements Storage {
 				});
 			}
 		}
+		const now = +new Date();
 		const setMintedStmt = this.d1.prepare(
-			"UPDATE nbtc_minting SET status = 'minted', updated_at = unixepoch('subsec') WHERE tx_id = ?",
+			`UPDATE nbtc_minting SET status = 'minted', updated_at = ${now} WHERE tx_id = ?`,
 		);
 		const setFailedStmt = this.d1.prepare(
-			"UPDATE nbtc_minting SET status = 'failed', updated_at = unixepoch('subsec') WHERE tx_id = ?",
+			`UPDATE nbtc_minting SET status = 'failed', updated_at = ${now} WHERE tx_id = ?`,
 		);
 		const updates = processedTxIds.map((p) =>
 			p.success ? setMintedStmt.bind(p.tx_id) : setFailedStmt.bind(p.tx_id),
@@ -351,9 +352,10 @@ export class Indexer implements Storage {
 	): Promise<{ reorgUpdates: D1PreparedStatement[]; reorgedTxIds: string[] }> {
 		const reorgUpdates: D1PreparedStatement[] = [];
 		const reorgedTxIds: string[] = [];
+		const now = +new Date();
 		const reorgCheckStmt = this.d1.prepare("SELECT hash FROM btc_blocks WHERE height = ?");
 		const reorgStmt = this.d1.prepare(
-			"UPDATE nbtc_minting SET status = 'reorg', updated_at = unixepoch('subsec') WHERE tx_id = ?",
+			`UPDATE nbtc_minting SET status = 'reorg', updated_at = ${now} WHERE tx_id = ?`,
 		);
 
 		for (const tx of pendingTxs) {
@@ -376,8 +378,9 @@ export class Indexer implements Storage {
 
 	selectFinalizedNbtcTxs(pendingTxs: PendingTx[], latestHeight: number): D1PreparedStatement[] {
 		const updates: D1PreparedStatement[] = [];
+		const now = +new Date();
 		const finalizeStmt = this.d1.prepare(
-			"UPDATE nbtc_minting SET status = 'finalized', updated_at = unixepoch('subsec') WHERE tx_id = ?",
+			`UPDATE nbtc_minting SET status = 'finalized', updated_at = ${now} WHERE tx_id = ?`,
 		);
 
 		for (const tx of pendingTxs) {


### PR DESCRIPTION
## Description

As discussed:
+ time is managed by the worker code
+ time is timestamp in MS

## Summary by Sourcery

Use worker-provided millisecond timestamps instead of database-generated unixepoch for transaction status updates and block processing.

Enhancements:
- Use JavaScript Date.now() to set updated_at in minting status updates (minted, failed, reorg, finalized).
- Change processed_at column in btc_blocks schema to integer without default to store millisecond timestamps.