### PR TITLE
feat: process transactions in groups

### DIFF
--- a/packages/btcindexer/src/btcindexer.test.ts
+++ b/packages/btcindexer/src/btcindexer.test.ts
@@ -57,7 +57,8 @@ const REGTEST_DATA: TestBlocks = {
 };
 
 const SUI_FALLBACK_ADDRESS = "0xFALLBACK";
-
+// TODO: ideally we should use Miniflare here, as in the auction tests. We can do it later.
+// https://github.com/gonative-cc/byield/blob/master/app/server/BeelieversAuction/auction.server.test.ts
 const createMockStmt = () => ({
 	bind: vi.fn().mockReturnThis(),
 	all: vi.fn().mockResolvedValue({ results: [] }),

--- a/packages/btcindexer/src/btcindexer.test.ts
+++ b/packages/btcindexer/src/btcindexer.test.ts
@@ -60,6 +60,7 @@ const SUI_FALLBACK_ADDRESS = "0xFALLBACK";
 
 const createMockStmt = () => ({
 	bind: vi.fn().mockReturnThis(),
+	all: vi.fn().mockResolvedValue({ results: [] }),
 });
 
 function mkMockD1() {
@@ -301,5 +302,43 @@ describe("Indexer.registerBroadcastedNbtcTx", () => {
 		await expect(indexer.registerBroadcastedNbtcTx(coinbaseTx.toHex())).rejects.toThrow(
 			"Transaction does not contain any valid nBTC deposits.",
 		);
+	});
+});
+
+describe("Indexer.processFinalizedTransactions", () => {
+	it("should process finalized transactions, group them, and call the SUI batch mint function", async () => {
+		const { mockEnv, indexer } = prepareIndexer();
+		const block303 = REGTEST_DATA[303];
+		const tx303 = block303.txs[1];
+		const mockFinalizedTxs = {
+			results: [
+				{
+					tx_id: tx303.id,
+					vout: 1,
+					block_hash: block303.hash,
+					block_height: block303.height,
+				},
+			],
+		};
+		const mockSelectStmt = createMockStmt();
+		mockSelectStmt.all.mockResolvedValue(mockFinalizedTxs);
+
+		const mockUpdateStmt = createMockStmt();
+		mockEnv.DB.prepare.mockReturnValueOnce(mockSelectStmt).mockReturnValue(mockUpdateStmt);
+
+		const mockKvGet = vi
+			.fn()
+			.mockResolvedValue(Buffer.from(block303.rawBlockHex, "hex").buffer);
+		mockEnv.btc_blocks.get = mockKvGet;
+
+		const suiClientSpy = vi
+			.spyOn(indexer.nbtcClient, "tryMintNbtcBatch")
+			.mockResolvedValue(true);
+		await indexer.processFinalizedTransactions();
+		expect(suiClientSpy).toHaveBeenCalledTimes(1);
+
+		const finalDbBatchCall = mockEnv.DB.batch.mock.calls[0][0];
+		expect(finalDbBatchCall).toHaveLength(1);
+		expect(mockUpdateStmt.bind).toHaveBeenCalledWith(expect.any(Number), tx303.id, 1);
 	});
 });

--- a/packages/btcindexer/src/models.ts
+++ b/packages/btcindexer/src/models.ts
@@ -17,10 +17,17 @@ export interface PendingTx {
 	block_height: number;
 }
 
-export interface BlockRecord {
+export interface FinalizedTxD1Row {
 	tx_id: string;
+	vout: number;
 	block_hash: string;
 	block_height: number;
+}
+
+export interface GroupedFinalizedTx {
+	block_hash: string;
+	block_height: number;
+	deposits: FinalizedTxD1Row[];
 }
 
 export interface Storage {

--- a/packages/btcindexer/src/models.ts
+++ b/packages/btcindexer/src/models.ts
@@ -17,7 +17,7 @@ export interface PendingTx {
 	block_height: number;
 }
 
-export interface FinalizedTxD1Row {
+export interface FinalizedTxRow {
 	tx_id: string;
 	vout: number;
 	block_hash: string;
@@ -27,7 +27,7 @@ export interface FinalizedTxD1Row {
 export interface GroupedFinalizedTx {
 	block_hash: string;
 	block_height: number;
-	deposits: FinalizedTxD1Row[];
+	deposits: FinalizedTxRow[];
 }
 
 export interface Storage {
@@ -47,7 +47,7 @@ export interface NbtcTxStatusResp {
 	amount_sats: number;
 }
 
-export interface NbtcTxD1Row {
+export interface NbtcTxRow {
 	tx_id: string;
 	block_hash: string;
 	block_height: number | null;


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Process finalized Bitcoin transactions in grouped batches to handle multiple deposits per transaction, update mint status per output (vout), and ensure correct batch minting in SUI.

New Features:
- Group finalized transactions by tx_id and aggregate their deposit outputs
- Include vout in SQL queries and status updates to track each UTXO individually
- Introduce models for FinalizedTxD1Row and GroupedFinalizedTx to support grouped processing

Enhancements:
- Refactor processFinalizedTransactions to build batch mint arguments per transaction group
- Modify database update statements to bind both tx_id and vout when marking records as minted or failed

Tests:
- Add unit test for processFinalizedTransactions to verify grouping logic and batch mint invocations