### PR TITLE
feat: add sui_tx_digest to the database

### DIFF
--- a/packages/btcindexer/db/migrations/0002_add_sui_tx_id.sql
+++ b/packages/btcindexer/db/migrations/0002_add_sui_tx_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE nbtc_minting ADD COLUMN sui_tx_id TEXT;

--- a/packages/btcindexer/src/btcindexer.test.ts
+++ b/packages/btcindexer/src/btcindexer.test.ts
@@ -333,14 +333,21 @@ describe("Indexer.processFinalizedTransactions", () => {
 			.mockResolvedValue(Buffer.from(block303.rawBlockHex, "hex").buffer);
 		mockEnv.btc_blocks.get = mockKvGet;
 
+		const fakeSuiTxDigest = "5fSnS1NCf2bYH39n18aGo41ggd2a7sWEy42533g46T2e";
 		const suiClientSpy = vi
 			.spyOn(indexer.nbtcClient, "tryMintNbtcBatch")
-			.mockResolvedValue(true);
+			.mockResolvedValue(fakeSuiTxDigest);
+
 		await indexer.processFinalizedTransactions();
 		expect(suiClientSpy).toHaveBeenCalledTimes(1);
 
 		const finalDbBatchCall = mockEnv.DB.batch.mock.calls[0][0];
 		expect(finalDbBatchCall).toHaveLength(1);
-		expect(mockUpdateStmt.bind).toHaveBeenCalledWith(expect.any(Number), tx303.id, 1);
+		expect(mockUpdateStmt.bind).toHaveBeenCalledWith(
+			fakeSuiTxDigest,
+			expect.any(Number),
+			tx303.id,
+			1,
+		);
 	});
 });

--- a/packages/btcindexer/src/btcindexer.ts
+++ b/packages/btcindexer/src/btcindexer.ts
@@ -485,13 +485,11 @@ export class Indexer implements Storage {
 		const confirmations = blockHeight ? latestHeight - blockHeight + 1 : 0;
 
 		return {
+			...tx,
 			btc_tx_id: tx.tx_id,
 			status: tx.status as NbtcTxStatus,
 			block_height: blockHeight,
 			confirmations: confirmations > 0 ? confirmations : 0,
-			sui_recipient: tx.sui_recipient,
-			amount_sats: tx.amount_sats,
-			sui_tx_id: tx.sui_tx_id,
 		};
 	}
 
@@ -512,13 +510,11 @@ export class Indexer implements Storage {
 			const blockHeight = tx.block_height as number;
 			const confirmations = blockHeight ? latestHeight - blockHeight + 1 : 0;
 			return {
+				...tx,
 				btc_tx_id: tx.tx_id,
 				status: tx.status as NbtcTxStatus,
 				block_height: blockHeight,
 				confirmations: confirmations > 0 ? confirmations : 0,
-				sui_recipient: tx.sui_recipient,
-				amount_sats: tx.amount_sats,
-				sui_tx_id: tx.sui_tx_id,
 			};
 		});
 	}

--- a/packages/btcindexer/src/btcindexer.ts
+++ b/packages/btcindexer/src/btcindexer.ts
@@ -349,32 +349,28 @@ export class Indexer implements Storage {
 
 		if (mintBatchArgs.length > 0) {
 			console.log(`Minting: Sending batch of ${mintBatchArgs.length} mints to SUI...`);
-			const batchSuccess = await this.nbtcClient.tryMintNbtcBatch(mintBatchArgs);
-
-			// If the whole batch fails, mark them all as failed
-			// TODO: decide what to do with the failed mints
-			if (!batchSuccess) {
-				processedPrimaryKeys.forEach((p) => {
-					if (p.success) p.success = false;
-				});
+			const suiTxDigest = await this.nbtcClient.tryMintNbtcBatch(mintBatchArgs);
+			const now = Date.now();
+			if (suiTxDigest) {
+				console.log(`Sui transaction successful. Digest: ${suiTxDigest}`);
+				const setMintedStmt = this.d1.prepare(
+					`UPDATE nbtc_minting SET status = 'minted', sui_tx_id = ?, updated_at = ? WHERE tx_id = ? AND vout = ?`,
+				);
+				const updates = processedPrimaryKeys.map((p) =>
+					setMintedStmt.bind(suiTxDigest, now, p.tx_id, p.vout),
+				);
+				console.log(`Minting: Updating status for ${updates.length} transactions in D1.`);
+				await this.d1.batch(updates);
+			} else {
+				const setFailedStmt = this.d1.prepare(
+					`UPDATE nbtc_minting SET status = 'failed', updated_at = ? WHERE tx_id = ? AND vout = ?`,
+				);
+				const updates = processedPrimaryKeys.map((p) =>
+					setFailedStmt.bind(now, p.tx_id, p.vout),
+				);
+				console.log(`Minting: Updating status for ${updates.length} transactions in D1.`);
+				await this.d1.batch(updates);
 			}
-		}
-		const now = Date.now();
-		const setMintedStmt = this.d1.prepare(
-			`UPDATE nbtc_minting SET status = 'minted', updated_at = ? WHERE tx_id = ? AND vout = ?`,
-		);
-		const setFailedStmt = this.d1.prepare(
-			`UPDATE nbtc_minting SET status = 'failed', updated_at = ? WHERE tx_id = ? AND vout = ?`,
-		);
-		const updates = processedPrimaryKeys.map((p) =>
-			p.success
-				? setMintedStmt.bind(now, p.tx_id, p.vout)
-				: setFailedStmt.bind(now, p.tx_id, p.vout),
-		);
-
-		if (updates.length > 0) {
-			console.log(`Minting: Updating status for ${updates.length} transactions in D1.`);
-			await this.d1.batch(updates);
 		}
 	}
 
@@ -495,6 +491,7 @@ export class Indexer implements Storage {
 			confirmations: confirmations > 0 ? confirmations : 0,
 			sui_recipient: tx.sui_recipient,
 			amount_sats: tx.amount_sats,
+			sui_tx_id: tx.sui_tx_id,
 		};
 	}
 
@@ -521,6 +518,7 @@ export class Indexer implements Storage {
 				confirmations: confirmations > 0 ? confirmations : 0,
 				sui_recipient: tx.sui_recipient,
 				amount_sats: tx.amount_sats,
+				sui_tx_id: tx.sui_tx_id,
 			};
 		});
 	}

--- a/packages/btcindexer/src/models.ts
+++ b/packages/btcindexer/src/models.ts
@@ -45,6 +45,7 @@ export interface NbtcTxStatusResp {
 	confirmations: number;
 	sui_recipient: string;
 	amount_sats: number;
+	sui_tx_id: string | null;
 }
 
 export interface NbtcTxRow {
@@ -57,6 +58,7 @@ export interface NbtcTxRow {
 	status: NbtcTxStatus;
 	created_at: number;
 	updated_at: number;
+	sui_tx_id: string | null;
 }
 
 export interface MintBatchArg {

--- a/packages/btcindexer/src/models.ts
+++ b/packages/btcindexer/src/models.ts
@@ -71,3 +71,5 @@ export interface MintBatchArg {
 export interface PostNbtcTxRequest {
 	txHex: string;
 }
+
+export type SuiTxDigest = string;

--- a/packages/btcindexer/src/sui_client.ts
+++ b/packages/btcindexer/src/sui_client.ts
@@ -3,7 +3,7 @@ import type { Signer } from "@mysten/sui/cryptography";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction as SuiTransaction } from "@mysten/sui/transactions";
 import { Transaction } from "bitcoinjs-lib";
-import { MintBatchArg, ProofResult } from "./models";
+import { MintBatchArg, ProofResult, SuiTxDigest } from "./models";
 
 export interface SuiClientCfg {
 	network: "testnet" | "mainnet" | "devnet" | "localnet";
@@ -101,7 +101,7 @@ export class SuiClient {
 		}
 	}
 
-	async mintNbtcBatch(mintArgs: MintBatchArg[]): Promise<string> {
+	async mintNbtcBatch(mintArgs: MintBatchArg[]): Promise<SuiTxDigest> {
 		if (mintArgs.length === 0) throw new Error("Mint arguments cannot be empty.");
 
 		const tx = new SuiTransaction();
@@ -138,7 +138,7 @@ export class SuiClient {
 		return result.digest;
 	}
 
-	async tryMintNbtcBatch(mintArgs: MintBatchArg[]): Promise<string | null> {
+	async tryMintNbtcBatch(mintArgs: MintBatchArg[]): Promise<SuiTxDigest | null> {
 		try {
 			return await this.mintNbtcBatch(mintArgs);
 		} catch (error) {

--- a/packages/btcindexer/src/sui_client.ts
+++ b/packages/btcindexer/src/sui_client.ts
@@ -101,8 +101,8 @@ export class SuiClient {
 		}
 	}
 
-	async mintNbtcBatch(mintArgs: MintBatchArg[]): Promise<void> {
-		if (mintArgs.length === 0) return;
+	async mintNbtcBatch(mintArgs: MintBatchArg[]): Promise<string> {
+		if (mintArgs.length === 0) throw new Error("Mint arguments cannot be empty.");
 
 		const tx = new SuiTransaction();
 		const target = `${this.nbtcPkg}::${this.nbtcModule}::mint` as const;
@@ -135,15 +135,15 @@ export class SuiClient {
 		if (result.effects?.status.status !== "success") {
 			throw new Error(`Batch mint transaction failed: ${result.effects?.status.error}`);
 		}
+		return result.digest;
 	}
 
-	async tryMintNbtcBatch(mintArgs: MintBatchArg[]): Promise<boolean> {
+	async tryMintNbtcBatch(mintArgs: MintBatchArg[]): Promise<string | null> {
 		try {
-			await this.mintNbtcBatch(mintArgs);
-			return true;
+			return await this.mintNbtcBatch(mintArgs);
 		} catch (error) {
 			console.error(`Error during batch mint contract call`, error);
-			return false;
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Closes: #74 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Persist SUI transaction digests for NBTC mint operations and update processing logic to record and handle these identifiers in the database.

New Features:
- Add sui_tx_id column to the nbtc_minting table and include it in query outputs
- Have SuiClient.mintNbtcBatch return the transaction digest and tryMintNbtcBatch return the digest or null instead of a boolean

Enhancements:
- Update Indexer to use the returned digest to mark mint records as 'minted' with sui_tx_id or 'failed'
- Update model interfaces to include a nullable sui_tx_id field

Build:
- Add SQL migration script to add the sui_tx_id column to nbtc_minting

Tests:
- Adjust minting tests to mock and assert on the returned SUI transaction digest