### PR TITLE
test(refactor): use bun test instead of vitest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ insert_final_newline = true
 # indent_style = space
 # indent_size = 4
 
-[*.{js,cjs,ts}]
+[*.{js,cjs,mjs,ts}]
 indent_style = tab
 indent_size = 4
 max_line_length = 100

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,21 +8,29 @@ import prettierConfig from "eslint-config-prettier";
 const ignore = globalIgnores(["packages/**/*.d.ts"]);
 
 export default tseslint.config(
-  ignore,
-  eslint.configs.recommended,
-  tseslint.configs.strict,
-  tseslint.configs.stylistic,
-  {
-    // disable specific rules
-    rules: {
-      "@typescript-eslint/no-extraneous-class": "off",
-      "@typescript-eslint/no-unused-vars": [
-        "warn",
-        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
-      ],
-    },
-  },
+	ignore,
+	eslint.configs.recommended,
+	tseslint.configs.strict,
+	tseslint.configs.stylistic,
+	{
+		// disable specific rules
+		rules: {
+			"@typescript-eslint/no-extraneous-class": "off",
+			"@typescript-eslint/no-unused-vars": [
+				"warn",
+				{ argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+			],
+		},
+	},
+	{
+		// Target all common test file patterns
+		files: ["**/*.test.ts", "**/*.spec.ts", "**/__tests__/**"],
+		rules: {
+			// Disable the non-null assertion rule only for these files
+			"@typescript-eslint/no-non-null-assertion": "off",
+		},
+	},
 
-  // Prettier configuration should be placed last to override any conflicting rules from earlier configurations.
-  prettierConfig,
+	// Prettier configuration should be placed last to override any conflicting rules from earlier configurations.
+	prettierConfig,
 );

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
 		"format": "prettier --write .",
 		"dev": "bun run --filter '*' dev",
-		"test": "bun run vitest run --reporter=verbose"
+		"test": "bun test"
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.9.2",

--- a/packages/btcindexer/package.json
+++ b/packages/btcindexer/package.json
@@ -13,7 +13,7 @@
 		"db:migrate:backstage": "wrangler d1 migrations apply btcindexer-dev --remote",
 		"typecheck": "tsc",
 		"cf-typegen": "wrangler types",
-		"test": "vitest run"
+		"test": "bun test"
 	},
 	"dependencies": {
 		"@mysten/sui": "^1.38.0",

--- a/packages/btcindexer/src/api/put-blocks.test.ts
+++ b/packages/btcindexer/src/api/put-blocks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert } from "vitest";
+import { describe, it, expect } from "bun:test";
 import { newPutBlock, PutBlocksReq } from "./put-blocks";
 import { Block } from "bitcoinjs-lib";
 
@@ -18,18 +18,20 @@ describe("encode PutBlocks", () => {
 	const block = Block.fromHex(blockHex);
 
 	it("should decode a single block", async () => {
-		assert(block.getId() == "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+		expect(block.getId()).toEqual(
+			"000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+		);
 
 		const expected = [newPutBlock(156, block)];
 		const reqBytes = PutBlocksReq.encode(expected);
 
 		const got = PutBlocksReq.decode(reqBytes);
-		assert.lengthOf(got, 1);
+		expect(got).toHaveLength(1);
 
 		const pb0 = got[0];
-		assert.equal(pb0.block.getId(), block.getId());
-		assert.equal(pb0.height, expected[0].height);
-		assert.include(bufferToHex(reqBytes), blockHex);
+		expect(pb0.block.getId()).toEqual(block.getId());
+		expect(pb0.height).toEqual(expected[0].height);
+		expect(bufferToHex(reqBytes)).toContain(blockHex);
 	});
 
 	it("should decode multiple blocks", async () => {
@@ -37,14 +39,14 @@ describe("encode PutBlocks", () => {
 		const expected = [newPutBlock(10, block), newPutBlock(11, block)];
 		const reqBytes = PutBlocksReq.encode(expected);
 		const got = PutBlocksReq.decode(reqBytes);
-		assert.lengthOf(got, 2);
-		assert.deepEqual(got, expected);
+		expect(got).toHaveLength(2);
+		expect(got).toEqual(expected);
 	});
 
 	it("should handle empty array", async () => {
 		const reqBytes = PutBlocksReq.encode([]);
 		const got = PutBlocksReq.decode(reqBytes);
-		assert.deepEqual(got, []);
+		expect(got).toEqual([]);
 	});
 
 	it("should abort on an invalid block", async () => {
@@ -52,6 +54,6 @@ describe("encode PutBlocks", () => {
 		const buffer = Buffer.from("invaliddddd", "utf8");
 		pbq.block = new Uint8Array(buffer);
 		const reqBytes = PutBlocksReq.msgpack([pbq]);
-		assert.throws(() => PutBlocksReq.decode(reqBytes), "Buffer too small");
+		expect(() => PutBlocksReq.decode(reqBytes)).toThrow("Buffer too small");
 	});
 });

--- a/packages/btcindexer/src/bitcoin-merkle-tree.test.ts
+++ b/packages/btcindexer/src/bitcoin-merkle-tree.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert } from "vitest";
+import { describe, it, expect } from "bun:test";
 import { Transaction } from "bitcoinjs-lib";
 import { BitcoinMerkleTree } from "./bitcoin-merkle-tree";
 
@@ -24,7 +24,7 @@ describe("BitcoinMerkleTree", () => {
 		const expectedRootHex = "701179cb9a9e0fe709cc96261b6b943b31362b61dacba94b03f9b71a06cc2eff";
 		const expectedRoot = Buffer.from(expectedRootHex, "hex"); // little-endian
 
-		assert.isTrue(tree.getRoot().equals(expectedRoot), "Merkle root doesn't match");
+		expect(tree.getRoot().equals(expectedRoot)).toBeTrue();
 	});
 
 	it("should generate the correct Merkle proof", () => {
@@ -38,9 +38,8 @@ describe("BitcoinMerkleTree", () => {
 		];
 		const expectedProof = expectedProofHex.map((hex) => Buffer.from(hex, "hex"));
 
-		assert.strictEqual(proof.length, 2, "Proof should have 2 elements");
-		assert.isTrue(proof[0].equals(expectedProof[0]), "First proof element is incorrect");
-		assert.isTrue(proof[1].equals(expectedProof[1]), "Second proof element is incorrect");
+		expect(proof[0].equals(expectedProof[0])).toBeTrue();
+		expect(proof[1].equals(expectedProof[1])).toBeTrue();
 	});
 
 	it("should generate the correct Merkle proof for segwit", () => {
@@ -53,7 +52,7 @@ describe("BitcoinMerkleTree", () => {
 		];
 		const expectedProof = expectedProofHex.map((hex) => Buffer.from(hex, "hex"));
 
-		assert.strictEqual(proof.length, 1, "Proof should have 1 element");
-		assert.isTrue(proof[0].equals(expectedProof[0]), "First proof element is incorrect");
+		expect(proof.length).toEqual(1);
+		expect(proof[0].equals(expectedProof[0])).toBeTrue();
 	});
 });

--- a/packages/btcindexer/src/btcindexer.ts
+++ b/packages/btcindexer/src/btcindexer.ts
@@ -149,7 +149,6 @@ export class Indexer implements Storage {
 			return;
 		}
 
-		const blockCount = blocksToProcess.results.length;
 		console.debug({
 			msg: "Cron: Found blocks to process",
 			count: blocksToProcess.results.length,

--- a/packages/btcindexer/src/sui_client.test.ts
+++ b/packages/btcindexer/src/sui_client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert } from "vitest";
+import { describe, it, expect } from "bun:test";
 import { Indexer } from "./btcindexer";
 import { SuiClient, SuiClientCfg } from "./sui_client";
 import { Block, networks } from "bitcoinjs-lib";
@@ -22,7 +22,7 @@ const SUI_CLIENT_CONFIG: SuiClientCfg = {
 
 // NOTE: skip to prevent this test from running in CI
 describe.skip("Sui Contract Integration", () => {
-	it("should successfully call the mint function on devnet", { timeout: 60000 }, async () => {
+	it("should successfully call the mint function on devnet", async () => {
 		const suiClient = new SuiClient(SUI_CLIENT_CONFIG);
 		const indexer = new Indexer(
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -35,20 +35,25 @@ describe.skip("Sui Contract Integration", () => {
 		);
 		const block = Block.fromHex(REGTEST_DATA.BLOCK_HEX);
 		const txIndex = block.transactions?.findIndex((tx) => tx.getId() === REGTEST_DATA.TX_ID);
-		assert(txIndex);
+		expect(txIndex).toBeDefined();
 		const targetTx = block.transactions?.[txIndex ?? -1];
-		assert(targetTx);
+		expect(targetTx).toBeDefined();
 
 		const tree = indexer.constructMerkleTree(block);
-		assert(tree);
-		const proofPath = indexer.getTxProof(tree, targetTx);
-		assert(proofPath);
-		const calculatedRoot = tree.getRoot();
+		expect(tree).toBeDefined();
+		const proofPath = indexer.getTxProof(tree!, targetTx!);
+		expect(proofPath).toBeDefined();
+		const calculatedRoot = tree!.getRoot();
 
-		const success = await suiClient.tryMintNbtc(targetTx, REGTEST_DATA.BLOCK_HEIGHT, txIndex, {
-			proofPath,
-			merkleRoot: calculatedRoot.toString("hex"),
-		});
-		assert.isTrue(success);
+		const success = await suiClient.tryMintNbtc(
+			targetTx!,
+			REGTEST_DATA.BLOCK_HEIGHT,
+			txIndex!,
+			{
+				proofPath: proofPath!,
+				merkleRoot: calculatedRoot.toString("hex"),
+			},
+		);
+		expect(success).toBe(true);
 	});
 });

--- a/packages/btcindexer/vitest.config.ts
+++ b/packages/btcindexer/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-	test: {
-		globals: true,
-	},
-});


### PR DESCRIPTION
## Description

## Summary by Sourcery

Migrate all project tests from Vitest to Bun's native test runner, update related scripts, configurations, and assertion syntax accordingly.

Enhancements:
- Migrate the test suite from Vitest to Bun's built-in test runner
- Replace fs.promises.readFile with Bun.file for test data loading

Build:
- Update test scripts in root and btcindexer package.json to use `bun test` instead of Vitest

Tests:
- Refactor test files to import from `bun:test` and use `expect` assertions instead of Vitest's API
- Adapt test code with non-null assertions and array checks compatible with Bun's runner

Chores:
- Add ESLint override to disable `no-non-null-assertion` rule for test files
- Remove the Vitest configuration file
- Remove a now-unused `blockCount` variable in Indexer implementation