### PR TITLE
bug: remove reversing of the proof

### DIFF
--- a/packages/btcindexer/src/sui_client.ts
+++ b/packages/btcindexer/src/sui_client.ts
@@ -106,8 +106,7 @@ export class SuiClient {
 		const tx = new SuiTransaction();
 		const target = `${this.nbtcPkg}::${this.nbtcModule}::mint` as const;
 
-		// NOTE: the contract is expecting the proofs to be in little-endian format, while the merkletreejs lib operates internally on big-endian.
-		const proofLittleEndian = proof.proofPath.map((p) => Array.from(Buffer.from(p).reverse()));
+		const proofLittleEndian = proof.proofPath.map((p) => Array.from(p));
 		const txBytes = Array.from(transaction.toBuffer());
 		tx.moveCall({
 			target: target,
@@ -165,7 +164,7 @@ export class SuiClient {
 		const target = `${this.nbtcPkg}::${this.nbtcModule}::mint` as const;
 
 		for (const args of mintArgs) {
-			const proofLittleEndian = args.proof.proofPath.map((p) => Array.from(p)).reverse();
+			const proofLittleEndian = args.proof.proofPath.map((p) => Array.from(p));
 			const txBytes = Array.from(args.tx.toBuffer());
 
 			tx.moveCall({


### PR DESCRIPTION
## Description

Closes: #135

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Fix proof endianness conversion by removing unnecessary reversing of proof bytes and proof path arrays in SuiClient's mint calls

Bug Fixes:
- Remove byte-order reversal when mapping proof path buffers
- Remove array-level reverse of proof path in mint argument processing