### PR TITLE
refactor(btcindexer): rename finalized-failed status to minted-fail

### DIFF
--- a/packages/btcindexer/src/btcindexer.ts
+++ b/packages/btcindexer/src/btcindexer.ts
@@ -350,6 +350,7 @@ export class Indexer {
 						txId,
 					});
 					try {
+						// TODO: need to distniguish FINALIZED_REORG and MINTED_REORG
 						await this.storage.updateTxsStatus([txId], TxStatus.FINALIZED_REORG);
 					} catch (e) {
 						console.error({
@@ -476,7 +477,7 @@ export class Indexer {
 						processedPrimaryKeys.map((p) => ({
 							tx_id: p.tx_id,
 							vout: p.vout,
-							status: TxStatus.MINTED_FAIL,
+							status: TxStatus.MINT_FAILED,
 						})),
 					);
 				}

--- a/packages/btcindexer/src/cf-storage.ts
+++ b/packages/btcindexer/src/cf-storage.ts
@@ -179,7 +179,7 @@ export class CFStorage implements Storage {
 	async getFinalizedTxs(maxRetries: number): Promise<FinalizedTxRow[]> {
 		const finalizedTxs = await this.d1
 			.prepare(
-				`SELECT tx_id, vout, block_hash, block_height, retry_count, nbtc_pkg, sui_network FROM nbtc_minting WHERE (status = '${TxStatus.FINALIZED}' OR (status = '${TxStatus.MINTED_FAIL}' AND retry_count <= ?)) AND status != '${TxStatus.FINALIZED_REORG}'`,
+				`SELECT tx_id, vout, block_hash, block_height, retry_count, nbtc_pkg, sui_network FROM nbtc_minting WHERE (status = '${TxStatus.FINALIZED}' OR (status = '${TxStatus.MINT_FAILED}' AND retry_count <= ?)) AND status != '${TxStatus.FINALIZED_REORG}'`,
 			)
 			.bind(maxRetries)
 			.all<FinalizedTxRow>();
@@ -215,7 +215,7 @@ export class CFStorage implements Storage {
 			if (p.status === TxStatus.MINTED) {
 				return setMintedStmt.bind(TxStatus.MINTED, p.suiTxDigest, now, p.tx_id, p.vout);
 			} else {
-				return setFailedStmt.bind(TxStatus.MINTED_FAIL, now, p.tx_id, p.vout);
+				return setFailedStmt.bind(TxStatus.MINT_FAILED, now, p.tx_id, p.vout);
 			}
 		});
 		try {

--- a/packages/btcindexer/src/models.ts
+++ b/packages/btcindexer/src/models.ts
@@ -52,7 +52,7 @@ export interface GroupedFinalizedTx {
  * - **confirming**: The deposit tx has been found in a Bitcoin block but does not yet have enough confirmations.
  * - **finalized**: The tx has reached the required confirmation depth and is ready to be minted.
  * - **minted**: The nBTC has been successfully minted on the SUI network.
- * - **minted-fail**: An attempt to mint a finalized tx failed. Mint should be retried.
+ * - **mint-failed**: An attempt to mint a finalized tx failed. Mint should be retried.
  * - **reorg**: A blockchain reorg detected while the tx was in the 'confirming' state. The tx block is no longer part of the canonical chain.
  * - **finalized-reorg**: An edge-case status indicating that a tx was marked 'finalized', but was later discovered to be on an orphaned (re-org deeper than the confirmation depth).
  */
@@ -60,7 +60,7 @@ export const enum TxStatus {
 	CONFIRMING = "confirming",
 	FINALIZED = "finalized",
 	MINTED = "minted",
-	MINTED_FAIL = "minted-fail",
+	MINT_FAILED = "mint-failed",
 	REORG = "reorg",
 	FINALIZED_REORG = "finalized-reorg",
 	BROADCASTING = "broadcasting",


### PR DESCRIPTION
## Description

## Summary by Sourcery

Rename the 'finalized-failed' mint status to 'minted-fail' across models, storage queries, and indexer logic

Enhancements:
- Rename TxStatus enum value FINALIZED_FAILED to MINTED_FAIL
- Update doc comments to describe the minted-fail status
- Adjust database queries and bindings to use the 'minted-fail' status
- Update indexer code to emit MINTED_FAIL instead of FINALIZED_FAILED