### PR TITLE
tests(btcindexer): verifyConfirmingBlocks and getSenderAddresses

### DIFF
--- a/packages/btcindexer/src/btcindexer.test.ts
+++ b/packages/btcindexer/src/btcindexer.test.ts
@@ -639,7 +639,7 @@ describe("Indexer.verifyConfirmingBlocks", () => {
 		const db = await mf.getD1Database("DB");
 		await db
 			.prepare(
-				"INSERT INTO nbtc_minting (tx_id, vout, block_hash, block_height, sui_recipient, amount_sats, status, created_at, updated_at, btc_network, nbtc_pkg, sui_network, deposit_address) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				"INSERT INTO nbtc_minting (tx_id, vout, block_hash, block_height, sui_recipient, amount_sats, status, created_at, updated_at, retry_count, btc_network, nbtc_pkg, sui_network, deposit_address) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 			)
 			.bind(
 				tx329.id,
@@ -651,6 +651,7 @@ describe("Indexer.verifyConfirmingBlocks", () => {
 				"confirming", // Set as confirming status
 				Date.now(),
 				Date.now(),
+				0,
 				BtcNet.REGTEST,
 				"0xPACKAGE",
 				"testnet",


### PR DESCRIPTION
## Description

## Summary by Sourcery

Add comprehensive tests for BTC indexer’s confirming blocks verification and sender address extraction in block processing

Tests:
- Add tests for verifyConfirmingBlocks covering valid, reorged, empty, and SPV verification failure scenarios
- Add tests for getSenderAddresses (via processBlock) handling Electrs API success, failure, and invalid responses