### PR TITLE
feat: utilize unused helpers in tests

### DIFF
--- a/packages/btcindexer/src/btcindexer.test.ts
+++ b/packages/btcindexer/src/btcindexer.test.ts
@@ -207,7 +207,10 @@ async function insertMintedTx(db: D1Database, txData: TxInfo) {
 	await insertTxWithStatus(db, txData.id, MintTxStatus.Minted, 0);
 }
 
-async function setupBlockInKV(kv: KVNamespace, blockData: TestBlock) {
+// type alias for exact type Miniflare returns
+type MiniflareKV = Awaited<ReturnType<Miniflare["getKVNamespace"]>>;
+
+async function putBlockInKv(kv: MiniflareKV, blockData: TestBlock) {
 	await kv.put(blockData.hash, Buffer.from(blockData.rawBlockHex, "hex").buffer);
 }
 
@@ -289,7 +292,7 @@ describe("Indexer.processBlock", () => {
 		};
 
 		const kv = await mf.getKVNamespace("BtcBlocks");
-		await kv.put(blockData.hash, Buffer.from(blockData.rawBlockHex, "hex").buffer);
+		await putBlockInKv(kv, blockData);
 
 		const fakeSenderAddress = "bc1qtestsenderaddress";
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -519,7 +522,7 @@ describe("Indexer.processFinalizedTransactions", () => {
 		await insertFinalizedTx(db, tx329);
 
 		const kv = await mf.getKVNamespace("BtcBlocks");
-		await kv.put(block329.hash, Buffer.from(block329.rawBlockHex, "hex").buffer);
+		await putBlockInKv(kv, block329);
 
 		const fakeSuiTxDigest = "5fSnS1NCf2bYH39n18aGo41ggd2a7sWEy42533g46T2e";
 		mockSuiClient.tryMintNbtcBatch.mockResolvedValue(fakeSuiTxDigest);
@@ -545,7 +548,7 @@ describe("Indexer.processFinalizedTransactions Retry Logic", () => {
 		await insertFinalizedTx(db, txData);
 
 		const kv = await mf.getKVNamespace("BtcBlocks");
-		await kv.put(blockData.hash, Buffer.from(blockData.rawBlockHex, "hex").buffer);
+		await putBlockInKv(kv, blockData);
 
 		const fakeSuiTxDigest = "5fSnS1NCf2bYH39n18aGo41ggd2a7sWEy42533g46T2e";
 		mockSuiClient.tryMintNbtcBatch.mockResolvedValue(fakeSuiTxDigest);
@@ -569,7 +572,7 @@ describe("Indexer.processFinalizedTransactions Retry Logic", () => {
 		await insertFinalizedTx(db, txData, 1);
 
 		const kv = await mf.getKVNamespace("BtcBlocks");
-		await kv.put(blockData.hash, Buffer.from(blockData.rawBlockHex, "hex").buffer);
+		await putBlockInKv(kv, blockData);
 
 		mockSuiClient.tryMintNbtcBatch.mockResolvedValue(null);
 
@@ -682,7 +685,7 @@ describe("Indexer.processBlock", () => {
 		};
 
 		const kv = await mf.getKVNamespace("BtcBlocks");
-		await kv.put(blockData.hash, Buffer.from(blockData.rawBlockHex, "hex").buffer);
+		await putBlockInKv(kv, blockData);
 
 		const fakeSenderAddress = "bc1qtestsenderaddress";
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -711,8 +714,7 @@ describe("Indexer.processBlock", () => {
 		const kv = await mf.getKVNamespace("BtcBlocks");
 
 		await insertMintedTx(db, txData);
-
-		await kv.put(blockData329.hash, Buffer.from(blockData329.rawBlockHex, "hex").buffer);
+		await putBlockInKv(kv, blockData329);
 
 		await db
 			.prepare(
@@ -727,7 +729,7 @@ describe("Indexer.processBlock", () => {
 			network: BtcNet.REGTEST,
 			timestamp_ms: timestamp_ms + 1000,
 		};
-		await kv.put(blockData327.hash, Buffer.from(blockData327.rawBlockHex, "hex").buffer);
+		await putBlockInKv(kv, blockData327);
 		await indexer.processBlock(reorgBlockInfo);
 		const status = await indexer.storage.getTxStatus(txData.id);
 		expect(status).toEqual(MintTxStatus.MintedReorg);
@@ -932,7 +934,7 @@ describe("Indexer.getSenderAddresses (via processBlock)", () => {
 		};
 
 		const kv = await mf.getKVNamespace("BtcBlocks");
-		await kv.put(blockData.hash, Buffer.from(blockData.rawBlockHex, "hex").buffer);
+		await putBlockInKv(kv, blockData);
 
 		if (mockElectrsResponse) {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description

Follow up to: #177

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Refactor BTC indexer tests to reuse a shared helper for writing blocks into the KV store.

Enhancements:
- Introduce a typed helper for putting blocks into the Miniflare KV namespace in tests to standardize KV interactions.

Tests:
- Update BTC indexer test cases to use the new KV block helper instead of duplicating KV put logic.