### PR TITLE
fix(btcindexer): getNbtcMintCandidates missing btc_network

### DIFF
--- a/packages/btcindexer/src/cf-storage.ts
+++ b/packages/btcindexer/src/cf-storage.ts
@@ -206,7 +206,7 @@ export class CFStorage implements Storage {
 	async getNbtcMintCandidates(maxRetries: number): Promise<FinalizedTxRow[]> {
 		const finalizedTxs = await this.d1
 			.prepare(
-				`SELECT m.tx_id, m.vout, m.block_hash, m.block_height, m.retry_count, p.nbtc_pkg, p.sui_network, p.btc_network, p.id as setup_id
+				`SELECT m.tx_id, m.vout, m.block_hash, m.block_height, p.nbtc_pkg, p.sui_network, p.btc_network, p.id as setup_id
 				 FROM nbtc_minting m
 				 JOIN nbtc_deposit_addresses a ON m.address_id = a.id
 				 JOIN setups p ON a.setup_id = p.id


### PR DESCRIPTION
## Description

- `FinalizedTxRow` requires a `btc_network: string`, but the query doesn’t select `p.btc_network`, so callers will receive `undefined` at runtime. Please include `p.btc_network` in the SELECT (and keep the column ordering consistent with `FinalizedTxRow`) to avoid this mismatch.
-  remove `retry_count` from select - it is not a field in the FinalizedTxRow interface. 

## Summary by Sourcery

Bug Fixes:
- Include the BTC network field in the getNbtcMintCandidates query to align results with the FinalizedTxRow schema and prevent undefined btc_network values at runtime.