### PR TITLE
feat(lib): introduce a base enum for BitcoinTxStatus

### DIFF
--- a/packages/btcindexer/src/models.ts
+++ b/packages/btcindexer/src/models.ts
@@ -72,15 +72,16 @@ export interface GroupedFinalizedTx {
  * - **minted-reorg**: An edge-case where a tx was successfully minted on Sui, but the Bitcoin deposit was later reorged. Tracked for monitoring purposes for now.
  * - **finalized-non-active**: The deposit has been finalized, however the minting will not be attempted because the deposit address is a non-active one. There will be a redemption mechanism for these cases.
  */
-enum mintTxStatus {
+enum MintTxStatusEnum {
 	Minted = "minted",
 	MintedReorg = "minted-reorg",
 	MintFailed = "mint-failed",
 	FinalizedNonActive = "finalized-non-active",
 }
 
-export type MintTxStatus = mintTxStatus | BitcoinTxStatus;
-export const MintTxStatus = { ...mintTxStatus, ...BitcoinTxStatus };
+export type MintTxStatus = MintTxStatusEnum | BitcoinTxStatus;
+// NOTE: In case of key conflicts, BitcoinTxStatus takes precedence because it is spread last.
+export const MintTxStatus = { ...MintTxStatusEnum, ...BitcoinTxStatus };
 
 export interface NbtcTxResp extends Omit<NbtcTxRow, "tx_id"> {
 	btcTxId: string;

--- a/packages/lib/src/nbtc.ts
+++ b/packages/lib/src/nbtc.ts
@@ -16,7 +16,7 @@ export interface BlockQueueRecord {
  * Represents the lifecycle status of a Bitcoin tx.
  * - **broadcasting**: The deposit transaction has been broadcast to the Bitcoin network, but has not yet been included in a block.
  * - **confirming**: The deposit tx has been found in a Bitcoin block but does not yet have enough confirmations.
- * - **finalized**: The tx has reached the required confirmation depth and is ready run finalization code.
+ * - **finalized**: The tx has reached the required confirmation depth and is ready to run finalization code.
  * - **reorg**: A blockchain reorg detected while the tx was in the 'confirming' state. The tx block is no longer part of the canonical chain.
  * - **finalized-reorg**: An edge-case status indicating that a tx was marked 'finalized', but was later discovered to be on an orphaned (re-org deeper than the confirmation depth).
  */


### PR DESCRIPTION
## Description


---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Introduce a shared BitcoinTxStatus enum in the lib package and refactor nBTC mint transaction status to build on it.

New Features:
- Add a reusable BitcoinTxStatus enum describing core Bitcoin transaction lifecycle states.
- Extend MintTxStatus to combine mint-specific statuses with the shared BitcoinTxStatus values.